### PR TITLE
Break ImagesLoaded out into another extension

### DIFF
--- a/MasonryMainPage.class.php
+++ b/MasonryMainPage.class.php
@@ -59,8 +59,6 @@ class MasonryMainPage
 
 		// There are issues loading Masonry via ResourceLoader in MW 1.27, but not in MW 1.25.
 		// Functionality in other MW versions is unknown at this writing.
-		$scriptURL = "$wgServer/$wgExtensionAssetsPath/MasonryMainPage/imagesloaded.pkgd.js";
-		$wgOut->addScript( "<script type='text/javascript' src='$scriptURL'></script>" );
 		$scriptURL = "$wgServer/$wgExtensionAssetsPath/MasonryMainPage/masonry.pkgd.js";
 		$wgOut->addScript( "<script type='text/javascript' src='$scriptURL'></script>" );
 

--- a/MasonryMainPage.php
+++ b/MasonryMainPage.php
@@ -41,7 +41,7 @@ if ( function_exists( 'wfLoadExtension' ) ) {
 		'url'            => 'http://github.com/enterprisemediawiki/MasonryMainPage',
 		'author'         => '[https://www.mediawiki.org/wiki/User:Darenwelsh Daren Welsh]',
 		'descriptionmsg' => 'masonrymainpage-desc',
-		'version'        => '0.3.0'
+		'version'        => '0.4.0'
 	);
 
 
@@ -52,7 +52,7 @@ if ( function_exists( 'wfLoadExtension' ) ) {
 	$wgAutoloadClasses['MasonryMainPage'] = __DIR__ . '/MasonryMainPage.class.php';
 
 	$wgResourceModules['ext.masonrymainpage.base'] = array(
-		'scripts' => array( 'imagesloaded.pkgd.js', 'masonry.pkgd.js', 'masonry-common.js' ),
+		'scripts' => array( 'masonry-common.js' ),
 		'styles' => 'Masonry.css',
 		'localBasePath' => __DIR__,
 		'remoteExtPath' => 'MasonryMainPage',

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 MasonryMainPage
-=========================
+===============
 
-This extension enables the use of Masonry blocks in MediaWiki. 
+This extension enables the use of Masonry blocks in MediaWiki.
 
 Masonry is developed by David DeSandro and information about that script can be found at http://masonry.desandro.com
 
-=========================
 USAGE
-=========================
+-----
 
 To enable this extension, append the following to LocalSettings.php
 
@@ -28,13 +27,13 @@ To use this extension in a MediaWiki page, add the following elements to the con
    Begin Masonry Blocks
 
 -->
-{{#masonry-block: title = 
- | width = 
- | color = 
- | body  = 
+{{#masonry-block: title =
+ | width =
+ | color =
+ | body  =
  }}
-{{#masonry-block: title = 
- | body  = 
+{{#masonry-block: title =
+ | body  =
  }}
 <!--
 
@@ -44,18 +43,17 @@ To use this extension in a MediaWiki page, add the following elements to the con
 </div>
 ```
 
-=========================
 OPTIONS
-=========================
+-------
 
 <ul><li>title = Title of your block (optional, will not show a header if omitted).</li>
 <li>width = 1 (or 2) (optional, default is 1).</li>
 <li>color = white (optional, default is green, options include orange, yellow, blue, white, purple, green, and none).</li>
 <li>body = This is the main content. Wiki code like links can be included; templates and wiki tables cannot.</li></ul>
 
-=========================
 TEMPLATES
-=========================
+---------
+
 Instead of clogging your main page with lots of content, you can also use templates.
 
 For example, you could create Template:Pages That Need Help Block with the content below:
@@ -76,9 +74,8 @@ Then, on the main page, just place {{Pages That Need Help Block}} in the Masonry
 
 
 
-=========================
 BACKGROUND INFO
-=========================
+---------------
 
 The parser function #masonry-block essentially adds the following code and applies some CSS:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This extension enables the use of Masonry blocks in MediaWiki.
 
 Masonry is developed by David DeSandro and information about that script can be found at http://masonry.desandro.com
 
+DEPENDENCIES
+------------
+
+* [Extension:ImagesLoaded](https://github.com/enterprisemediawiki/ImagesLoaded)
+
 USAGE
 -----
 


### PR DESCRIPTION
The "ImagesLoaded" library is now broken out into another extension. This allows that function to be used in other places (e.g. other extensions and MediaWiki:Common.js).

Also bump version and fix readme.